### PR TITLE
WindowsEventLog: Update MaximumSizeInBytes value in example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - ScheduledTask:
   - Fixed bug when description has any form of whitespace at beginning or
     end the resource would not go into state - Fixes [Issue #258](https://github.com/PowerShell/ComputerManagementDsc/issues/258).
+- WindowsEventLog: Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1 with a number in bytes, because other units are not recognized.
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 - ScheduledTask:
   - Fixed bug when description has any form of whitespace at beginning or
     end the resource would not go into state - Fixes [Issue #258](https://github.com/PowerShell/ComputerManagementDsc/issues/258).
-- WindowsEventLog: Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1 with a number in bytes, because other units are not recognized.
+- WindowsEventLog:
+  - Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
+    with a number in bytes, because other units are not recognized.
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- SmbShare:
+  - Add parameter ScopeName to support creating shares in a different
+    scope. Fixes [Issue #284](https://github.com/PowerShell/ComputerManagementDsc/issues/284)
+- Added `.gitattributes` to ensure CRLF is used when pulling repository - Fixes
+  [Issue #290](https://github.com/PowerShell/ComputerManagementDsc/issues/290).
+- SystemLocale:
+  - Migrated SystemLocale from [SystemLocaleDsc](https://github.com/PowerShell/SystemLocaleDsc).
+- RemoteDesktopAdmin:
+  - Correct Context messages in integration tests by adding 'When'.
+- WindowsEventLog:
+  - Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
+    with a number in bytes, because other units are not recognized.
+
+## 7.1.0.0
+
 - ComputerManagementDsc:
   - Update psd1 description - Fixes [Issue #269](https://github.com/PowerShell/ComputerManagementDsc/issues/269).
 - Fix minor style issues with missing spaces between `param` statements and '('.
@@ -12,9 +27,12 @@
 - ScheduledTask:
   - Fixed bug when description has any form of whitespace at beginning or
     end the resource would not go into state - Fixes [Issue #258](https://github.com/PowerShell/ComputerManagementDsc/issues/258).
-- WindowsEventLog:
-  - Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
-    with a number in bytes, because other units are not recognized.
+- SmbShare:
+  - Fixed bug where the resource would not update the path of a share if the
+    share exists on a different path. Adds a parameter Force to the SmbShare
+    resource to allow updating of the path - Fixes [Issue #215](https://github.com/PowerShell/ComputerManagementDsc/issues/215)
+  - Removal of duplicate code in Add-SmbShareAccessPermission helper function
+    fixes [Issue #226](https://github.com/PowerShell/ComputerManagementDsc/issues/226).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - Fixed bug when description has any form of whitespace at beginning or
     end the resource would not go into state - Fixes [Issue #258](https://github.com/PowerShell/ComputerManagementDsc/issues/258).
 - WindowsEventLog:
-  - Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
+  - Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1  
     with a number in bytes, because other units are not recognized.
 
 ## 7.0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,6 @@
 
 ## Unreleased
 
-- SmbShare:
-  - Add parameter ScopeName to support creating shares in a different
-    scope. Fixes [Issue #284](https://github.com/PowerShell/ComputerManagementDsc/issues/284)
-- Added `.gitattributes` to ensure CRLF is used when pulling repository - Fixes
-  [Issue #290](https://github.com/PowerShell/ComputerManagementDsc/issues/290).
-- SystemLocale:
-  - Migrated SystemLocale from [SystemLocaleDsc](https://github.com/PowerShell/SystemLocaleDsc).
-- RemoteDesktopAdmin:
-  - Correct Context messages in integration tests by adding 'When'.
-- Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
-    with a number in bytes, because other units are not recognized.
-
-## 7.1.0.0
-
 - ComputerManagementDsc:
   - Update psd1 description - Fixes [Issue #269](https://github.com/PowerShell/ComputerManagementDsc/issues/269).
 - Fix minor style issues with missing spaces between `param` statements and '('.
@@ -26,12 +12,9 @@
 - ScheduledTask:
   - Fixed bug when description has any form of whitespace at beginning or
     end the resource would not go into state - Fixes [Issue #258](https://github.com/PowerShell/ComputerManagementDsc/issues/258).
-- SmbShare:
-  - Fixed bug where the resource would not update the path of a share if the
-    share exists on a different path. Adds a parameter Force to the SmbShare
-    resource to allow updating of the path - Fixes [Issue #215](https://github.com/PowerShell/ComputerManagementDsc/issues/215)
-  - Removal of duplicate code in Add-SmbShareAccessPermission helper function
-    fixes [Issue #226](https://github.com/PowerShell/ComputerManagementDsc/issues/226).
+- WindowsEventLog:
+  - Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
+    with a number in bytes, because other units are not recognized.
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- SmbShare:
+  - Add parameter ScopeName to support creating shares in a different
+    scope. Fixes [Issue #284](https://github.com/PowerShell/ComputerManagementDsc/issues/284)
+- Added `.gitattributes` to ensure CRLF is used when pulling repository - Fixes
+  [Issue #290](https://github.com/PowerShell/ComputerManagementDsc/issues/290).
+- SystemLocale:
+  - Migrated SystemLocale from [SystemLocaleDsc](https://github.com/PowerShell/SystemLocaleDsc).
+- RemoteDesktopAdmin:
+  - Correct Context messages in integration tests by adding 'When'.
+- Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
+    with a number in bytes, because other units are not recognized.
+
+## 7.1.0.0
+
 - ComputerManagementDsc:
   - Update psd1 description - Fixes [Issue #269](https://github.com/PowerShell/ComputerManagementDsc/issues/269).
 - Fix minor style issues with missing spaces between `param` statements and '('.
@@ -12,9 +26,12 @@
 - ScheduledTask:
   - Fixed bug when description has any form of whitespace at beginning or
     end the resource would not go into state - Fixes [Issue #258](https://github.com/PowerShell/ComputerManagementDsc/issues/258).
-- WindowsEventLog:
-  - Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
-    with a number in bytes, because other units are not recognized.
+- SmbShare:
+  - Fixed bug where the resource would not update the path of a share if the
+    share exists on a different path. Adds a parameter Force to the SmbShare
+    resource to allow updating of the path - Fixes [Issue #215](https://github.com/PowerShell/ComputerManagementDsc/issues/215)
+  - Removal of duplicate code in Add-SmbShareAccessPermission helper function
+    fixes [Issue #226](https://github.com/PowerShell/ComputerManagementDsc/issues/226).
 
 ## 7.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   - Fixed bug when description has any form of whitespace at beginning or
     end the resource would not go into state - Fixes [Issue #258](https://github.com/PowerShell/ComputerManagementDsc/issues/258).
 - WindowsEventLog:
-  - Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1  
+  - Updated example 3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
     with a number in bytes, because other units are not recognized.
 
 ## 7.0.0.0

--- a/Examples/Resources/WindowsEventlog/3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
+++ b/Examples/Resources/WindowsEventlog/3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
@@ -1,5 +1,5 @@
 <#PSScriptInfo
-.VERSION 1.0.0
+.VERSION 1.0.1
 .GUID f05286e4-e357-40f8-ba62-e49d4d50eb0f
 .AUTHOR Microsoft Corporation
 .COMPANYNAME Microsoft Corporation

--- a/Examples/Resources/WindowsEventlog/3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
+++ b/Examples/Resources/WindowsEventlog/3-WindowsEventlog_EnableWindowsEventLog_Config.ps1
@@ -33,7 +33,7 @@ Configuration WindowsEventlog_EnableWindowsEventLog_Config
             LogName             = 'Microsoft-Windows-Dsc/Analytic'
             IsEnabled           = $True
             LogMode             = 'Retain'
-            MaximumSizeInBytes  = 4096kb
+            MaximumSizeInBytes  = 4194304
             LogFilePath         = "%SystemRoot%\System32\Winevt\Logs\Microsoft-Windows-DSC%4Analytic.evtx"
         } # End of Windows Event Log Resource
     } # End of Node


### PR DESCRIPTION
#### This Pull Request (PR) fixes the following issues
The former value of 4096kb in the example does not work. And it's the same for any size unit like kb, mb, gb, ...

It generates the following error message:

> Compilation errors occurred while processing configuration 'DscConfigurationName'. Please review the errors reported in error stream and modify your configuration code appropriately.
>     + CategoryInfo          : InvalidOperation: (DscConfiguration:String) [], InvalidOperationException
>     + FullyQualifiedErrorId : FailToProcessConfiguration

Entering only a number works fine.

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/computermanagementdsc/278)
<!-- Reviewable:end -->
