### PR TITLE
ScheduledTask: Resolved inconsistent treatment of BuiltInAccount property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- WindowsCapability:
+  - Fix `A parameter cannot be found that matches parameter name 'Ensure'.`
+    error in `Test-TargetResource` - Fixes [Issue #297](https://github.com/dsccommunity/ComputerManagementDsc/issues/297).
+
 ## [8.0.0] - 2020-02-14
 
 ### Added
@@ -41,9 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- WindowsCapability:
-  - Fix `A parameter cannot be found that matches parameter name 'Ensure'.`
-    error in `Test-TargetResource` - Fixes [Issue #297](https://github.com/dsccommunity/ComputerManagementDsc/issues/297).
 - ScheduledTask:
   - Added missing 'NT Authority\' domain prefix when testing tasks that use the BuiltInAccount property - Fixes
     [Issue #317](https://github.com/dsccommunity/ComputerManagementDsc/issues/317)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- ScheduledTask:
-  - Added missing 'NT Authority\' domain prefix when testing tasks that use the BuiltInAccount property.
-  
 ## [8.0.0] - 2020-02-14
 
 ### Added
@@ -47,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WindowsCapability:
   - Fix `A parameter cannot be found that matches parameter name 'Ensure'.`
     error in `Test-TargetResource` - Fixes [Issue #297](https://github.com/dsccommunity/ComputerManagementDsc/issues/297).
+- ScheduledTask:
+  - Added missing 'NT Authority\' domain prefix when testing tasks that use the BuiltInAccount property.
+  - Fixes [Issue #317](https://github.com/dsccommunity/ComputerManagementDsc/issues/317)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- WindowsCapability:
-  - Fix `A parameter cannot be found that matches parameter name 'Ensure'.`
-    error in `Test-TargetResource` - Fixes [Issue #297](https://github.com/dsccommunity/ComputerManagementDsc/issues/297).
+- ScheduledTask:
+  - Added missing 'NT Authority\' domain prefix when testing tasks that use
+    the BuiltInAccount property - Fixes [Issue #317](https://github.com/dsccommunity/ComputerManagementDsc/issues/317)
 
 ## [8.0.0] - 2020-02-14
 
@@ -66,9 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- ScheduledTask:
-  - Added missing 'NT Authority\' domain prefix when testing tasks that use the BuiltInAccount property - Fixes
-    [Issue #317](https://github.com/dsccommunity/ComputerManagementDsc/issues/317)
+- WindowsCapability:
+  - Fix `A parameter cannot be found that matches parameter name 'Ensure'.`
+    error in `Test-TargetResource` - Fixes [Issue #297](https://github.com/dsccommunity/ComputerManagementDsc/issues/297).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ScheduledTask:
+  - Added missing 'NT Authority\' domain prefix when testing tasks that use the BuiltInAccount property.
+  
 ## [8.0.0] - 2020-02-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fix `A parameter cannot be found that matches parameter name 'Ensure'.`
     error in `Test-TargetResource` - Fixes [Issue #297](https://github.com/dsccommunity/ComputerManagementDsc/issues/297).
 - ScheduledTask:
-  - Added missing 'NT Authority\' domain prefix when testing tasks that use the BuiltInAccount property.
-  - Fixes [Issue #317](https://github.com/dsccommunity/ComputerManagementDsc/issues/317)
+  - Added missing 'NT Authority\' domain prefix when testing tasks that use the BuiltInAccount property - Fixes
+    [Issue #317](https://github.com/dsccommunity/ComputerManagementDsc/issues/317)
 
 ### Security
 

--- a/source/DSCResources/DSC_ScheduledTask/DSC_ScheduledTask.psm1
+++ b/source/DSCResources/DSC_ScheduledTask/DSC_ScheduledTask.psm1
@@ -1408,6 +1408,8 @@ function Test-TargetResource
 
         $PSBoundParameters['LogonType'] = 'ServiceAccount'
         $currentValues['LogonType'] = 'ServiceAccount'
+
+        $PSBoundParameters['BuiltInAccount'] = 'NT AUTHORITY\' + $BuiltInAccount
     }
     elseif ($PSBoundParameters.ContainsKey('ExecuteAsCredential'))
     {

--- a/tests/Integration/DSC_ScheduledTask.Integration.Tests.ps1
+++ b/tests/Integration/DSC_ScheduledTask.Integration.Tests.ps1
@@ -39,6 +39,7 @@ try
                 ExecuteAs         = 'ScheduledTaskExecuteAs'
                 ExecuteAsGroup    = 'ScheduledTaskExecuteAsGroup'
                 OnEvent           = 'ScheduledTaskOnEvent'
+                BuiltInAccount    = 'ScheduledTaskServiceAccount'
             }
 
             $configData = @{

--- a/tests/Integration/DSC_ScheduledTask.config.ps1
+++ b/tests/Integration/DSC_ScheduledTask.config.ps1
@@ -259,6 +259,28 @@ Configuration ScheduledTaskOnEventAdd
     }
 }
 
+Configuration ScheduledTaskServiceAccountAdd
+{
+    Import-DscResource -ModuleName ComputerManagementDsc
+
+    node 'localhost'
+    {
+        ScheduledTask ScheduledTaskServiceAccountAdd
+        {
+            TaskName           = 'Test task BuiltInAccount'
+            TaskPath           = '\ComputerManagementDsc\'
+            Ensure             = 'Present'
+            LogonType          = 'ServiceAccount'
+            BuiltInAccount     = 'LOCAL SERVICE'
+            RunLevel           = 'Limited'
+            ActionExecutable   = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+            ScheduleType       = 'Once'
+            RepeatInterval     = '00:15:00'
+            RepetitionDuration = 'Indefinitely'
+        }
+    }
+}
+
 Configuration ScheduledTaskOnceMod
 {
     Import-DscResource -ModuleName ComputerManagementDsc
@@ -425,6 +447,28 @@ Configuration ScheduledTaskOnEventMod
             ActionArguments   = '-Command Set-Content -Path c:\temp\seeme.txt -Value ''Worked!'''
             EventSubscription = '<QueryList><Query Id="0" Path="System"><Select Path="System">*[System[Provider[@Name=''Service Control Manager''] and (Level=2) and (EventID=7002)]]</Select></Query></QueryList>'
             Delay             = '00:00:45'
+        }
+    }
+}
+
+Configuration ScheduledTaskServiceAccountMod
+{
+    Import-DscResource -ModuleName ComputerManagementDsc
+
+    node 'localhost'
+    {
+        ScheduledTask ScheduledTaskServiceAccountMod
+        {
+            TaskName           = 'Test task BuiltInAccount'
+            TaskPath           = '\ComputerManagementDsc\'
+            Ensure             = 'Present'
+            LogonType          = 'ServiceAccount'
+            BuiltInAccount     = 'NETWORK SERVICE'
+            RunLevel           = 'Limited'
+            ActionExecutable   = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+            ScheduleType       = 'Once'
+            RepeatInterval     = '00:15:00'
+            RepetitionDuration = 'Indefinitely'
         }
     }
 }
@@ -600,6 +644,29 @@ Configuration ScheduledTaskOnEventDel
             ActionArguments   = '-Command Set-Content -Path c:\temp\seeme.txt -Value ''Worked!'''
             EventSubscription = '<QueryList><Query Id="0" Path="System"><Select Path="System">*[System[Provider[@Name=''Service Control Manager''] and (Level=2) and (EventID=7001)]]</Select></Query></QueryList>'
             Delay             = '00:00:30'
+        }
+    }
+}
+
+Configuration ScheduledTaskServiceAccountDel
+{
+    Import-DscResource -ModuleName ComputerManagementDsc
+
+    node 'localhost'
+    {
+        ScheduledTask ScheduledTaskServiceAccountDel
+        {
+            TaskName           = 'Test task BuiltInAccount'
+            TaskPath           = '\ComputerManagementDsc\'
+            Ensure             = 'Absent'
+            LogonType          = 'ServiceAccount'
+            BuiltInAccount     = 'LOCAL SERVICE'
+            RunLevel           = 'Limited'
+            ActionExecutable   = 'C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe'
+            ScheduleType       = 'Once'
+            RepeatInterval     = '00:15:00'
+            RepetitionDuration = 'Indefinitely'
+            ActionWorkingPath  = (Get-Location).Path
         }
     }
 }

--- a/tests/Unit/DSC_ScheduledTask.Tests.ps1
+++ b/tests/Unit/DSC_ScheduledTask.Tests.ps1
@@ -1723,7 +1723,7 @@ try
                             }
                         )
                         Principal = [pscustomobject] @{
-                            UserId    = $testParameters.BuiltInAccount
+                            UserId    = 'NT AUTHORITY\' + $testParameters.BuiltInAccount
                             LogonType = 'ServiceAccount'
                         }
                     }


### PR DESCRIPTION
#### Pull Request (PR) description
Fixed inconsistent treatment of the BuiltInAccount property for the ScheduledTask resource.
The Set method prefixes the "SYSTEM", "LOCAL SERVICE", "NETWORK SERVICE" account names with the "NT Authority\" domain.
This results in a scheduled task that runs, but the DSC resource test will always fail on the BuiltInAccount property check. For example:
Expected = 'SYSTEM'
Actual = 'NT Authority\SYSTEM.'

Added integration test cases for the ServiceAccount Logontype/BuiltInAccount property, demonstrating the above.


#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/computermanagementdsc/313)
<!-- Reviewable:end -->
