### PR TITLE
Improve integration test reliability - Fixes #329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - ComputerManagementDsc
   - Updated to use the common module _DscResource.Common_ - Fixes [Issue #327](https://github.com/dsccommunity/ComputerManagementDsc/issues/327).
   - Fixed build failures caused by changes in `ModuleBuilder` module v1.7.0
@@ -13,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     coverage - Fixes [Issue #336](https://github.com/dsccommunity/ComputerManagementDsc/issues/336).
 - ScheduledTask
   - Add "StopExisting" to valid values for MultipleInstances parameter - Fixes [Issue #333](https://github.com/dsccommunity/ComputerManagementDsc/issues/333).
+
+### Fixed
+
+- ComputerManagementDsc
+  - Improved integration test reliability by resetting the DSC LCM
+    before executing each test using the `Reset-DscLcm` function - Fixes [Issue #329](https://github.com/dsccommunity/ComputerManagementDsc/issues/329).
+  - Split integration test MOF compilation out of application to standardize
+    pattern and make it easier to determine cause of failure.
 
 ## [8.2.0] - 2020-05-05
 

--- a/tests/Integration/DSC_IEEnhancedSecurityConfiguration.Integration.Tests.ps1
+++ b/tests/Integration/DSC_IEEnhancedSecurityConfiguration.Integration.Tests.ps1
@@ -41,6 +41,8 @@ try
                     -OutputPath $TestDrive `
                     -ConfigurationData $configData
 
+                Reset-DscLcm
+
                 $startDscConfigurationParameters = @{
                     Path         = $TestDrive
                     ComputerName = 'localhost'
@@ -82,11 +84,17 @@ try
             )
         }
 
-        It 'Should compile and apply the MOF without throwing' {
+        It 'Should compile the MOF without throwing' {
             {
                 & "$($script:dscResourceName)_Config" `
                     -OutputPath $TestDrive `
                     -ConfigurationData $configData
+           } | Should -Not -Throw
+        }
+
+        It 'Should apply the MOF without throwing' {
+            {
+                Reset-DscLcm
 
                 $startDscConfigurationParameters = @{
                     Path         = $TestDrive

--- a/tests/Integration/DSC_PendingReboot.Tests.ps1
+++ b/tests/Integration/DSC_PendingReboot.Tests.ps1
@@ -97,8 +97,6 @@ try
 
             It 'Should apply the MOF without throwing' {
                 {
-
-
                     Reset-DscLcm
 
                     $startDscConfigurationParameters = @{

--- a/tests/Integration/DSC_PendingReboot.Tests.ps1
+++ b/tests/Integration/DSC_PendingReboot.Tests.ps1
@@ -87,11 +87,19 @@ try
                 )
             }
 
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     & "$($script:dscResourceName)_Config" `
                         -OutputPath $TestDrive `
                         -ConfigurationData $configData
+               } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+
+
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive

--- a/tests/Integration/DSC_PowerShellExecutionPolicy.Integration.Tests.ps1
+++ b/tests/Integration/DSC_PowerShellExecutionPolicy.Integration.Tests.ps1
@@ -26,9 +26,15 @@ try
         . $configFile
 
         Describe "$($script:dscResourceName)_Integration" {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     & "$($script:dscResourceName)_Config" -OutputPath $TestDrive
+               } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive

--- a/tests/Integration/DSC_RemoteDesktopAdmin.Integration.Tests.ps1
+++ b/tests/Integration/DSC_RemoteDesktopAdmin.Integration.Tests.ps1
@@ -34,14 +34,16 @@ try
                 $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
                 $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
 
-                It 'Should compile a MOF file without error' {
+                It 'Should compile the MOF without throwing' {
                     {
                         . $CurrentConfig -OutputPath $ConfigDir
                     } | Should -Not -Throw
                 }
 
-                It 'Should apply the MOF correctly' {
+                It 'Should apply the MOF without throwing' {
                     {
+                        Reset-DscLcm
+
                         Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
@@ -66,14 +68,16 @@ try
                 $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
                 $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
 
-                It 'Should compile a MOF file without error' {
+                It 'Should compile the MOF without throwing' {
                     {
                         . $CurrentConfig -OutputPath $ConfigDir
                     } | Should -Not -Throw
                 }
 
-                It 'Should apply the MOF correctly' {
+                It 'Should apply the MOF without throwing' {
                     {
+                        Reset-DscLcm
+
                         Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
@@ -98,14 +102,16 @@ try
                 $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
                 $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
 
-                It 'Should compile a MOF file without error' {
+                It 'Should compile the MOF without throwing' {
                     {
                         . $CurrentConfig -OutputPath $ConfigDir
                     } | Should -Not -Throw
                 }
 
-                It 'Should apply the MOF correctly' {
+                It 'Should apply the MOF without throwing' {
                     {
+                        Reset-DscLcm
+
                         Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
@@ -132,14 +138,16 @@ try
                 $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
                 $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
 
-                It 'Should compile a MOF file without error' {
+                It 'Should compile the MOF without throwing' {
                     {
                         . $CurrentConfig -OutputPath $ConfigDir
                     } | Should -Not -Throw
                 }
 
-                It 'Should apply the MOF correctly' {
+                It 'Should apply the MOF without throwing' {
                     {
+                        Reset-DscLcm
+
                         Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }

--- a/tests/Integration/DSC_ScheduledTask.Integration.Tests.ps1
+++ b/tests/Integration/DSC_ScheduledTask.Integration.Tests.ps1
@@ -68,6 +68,8 @@ try
 
                     It 'Should apply the MOF correctly' {
                         {
+                            Reset-DscLcm
+
                             Start-DscConfiguration `
                                 -Path $configDir `
                                 -Wait `
@@ -97,6 +99,8 @@ try
 
                     It 'Should apply the MOF correctly' {
                         {
+                            Reset-DscLcm
+
                             Start-DscConfiguration `
                                 -Path $configDir `
                                 -Wait `
@@ -126,6 +130,8 @@ try
 
                     It 'Should apply the MOF correctly' {
                         {
+                            Reset-DscLcm
+
                             Start-DscConfiguration `
                                 -Path $configDir `
                                 -Wait `
@@ -162,6 +168,9 @@ try
                 It 'Should apply the MOF correctly in New Zealand Standard Time Timezone' {
                     {
                         Set-TimeZoneId -TimeZoneId 'New Zealand Standard Time'
+
+                        Reset-DscLcm
+
                         Start-DscConfiguration `
                             -Path $configDir `
                             -Wait `
@@ -212,6 +221,8 @@ try
 
                 It 'Should apply the MOF correctly' {
                     {
+                        Reset-DscLcm
+
                         Start-DscConfiguration `
                             -Path $configDir `
                             -Wait `
@@ -259,6 +270,8 @@ try
 
                 It 'Should apply the MOF correctly' {
                     {
+                        Reset-DscLcm
+
                         Start-DscConfiguration `
                             -Path $configDir `
                             -Wait `
@@ -313,6 +326,8 @@ try
 
                 It 'Should apply the MOF correctly' {
                     {
+                        Reset-DscLcm
+
                         Start-DscConfiguration `
                             -Path $configDir `
                             -Wait `
@@ -352,6 +367,8 @@ try
 
                 It 'Should apply the MOF correctly' {
                     {
+                        Reset-DscLcm
+
                         Start-DscConfiguration `
                             -Path $configDir `
                             -Wait `

--- a/tests/Integration/DSC_SmbServerConfiguration.Tests.ps1
+++ b/tests/Integration/DSC_SmbServerConfiguration.Tests.ps1
@@ -80,11 +80,17 @@ try
                 )
             }
 
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     & "$($script:dscResourceName)_Config" `
                         -OutputPath $TestDrive `
                         -ConfigurationData $configData
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive

--- a/tests/Integration/DSC_SmbShare.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SmbShare.Integration.Tests.ps1
@@ -28,7 +28,7 @@ try
         $configurationName = "$($script:dscResourceName)_Prerequisites_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     $configurationParameters = @{
                         OutputPath        = $TestDrive
@@ -36,6 +36,12 @@ try
                     }
 
                     & $configurationName @configurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive
@@ -54,7 +60,7 @@ try
         $configurationName = "$($script:dscResourceName)_CreateShare1_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     $configurationParameters = @{
                         OutputPath        = $TestDrive
@@ -62,6 +68,12 @@ try
                     }
 
                     & $configurationName @configurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive
@@ -122,7 +134,7 @@ try
         $configurationName = "$($script:dscResourceName)_CreateShare2_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     $configurationParameters = @{
                         OutputPath        = $TestDrive
@@ -130,6 +142,12 @@ try
                     }
 
                     & $configurationName @configurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive
@@ -189,7 +207,7 @@ try
         $configurationName = "$($script:dscResourceName)_UpdateProperties_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     $configurationParameters = @{
                         OutputPath        = $TestDrive
@@ -197,6 +215,12 @@ try
                     }
 
                     & $configurationName @configurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive
@@ -227,11 +251,7 @@ try
                 $resourceCurrentState.Name | Should -Be $ConfigurationData.AllNodes.ShareName1
                 $resourceCurrentState.Path | Should -Be $ConfigurationData.AllNodes.SharePath1
                 $resourceCurrentState.Description | Should -Be 'A new description'
-                #$resourceCurrentState.EncryptData | Should -BeTrue
                 $resourceCurrentState.ConcurrentUserLimit | Should -Be 20
-                #$resourceCurrentState.FolderEnumerationMode | Should -Be 'AccessBased'
-                #$resourceCurrentState.CachingMode | Should -Be 'None'
-                #$resourceCurrentState.ContinuouslyAvailable | Should -BeTrue
                 $resourceCurrentState.ShareState | Should -Be 'Online'
                 $resourceCurrentState.ShareType | Should -Be 'FileSystemDirectory'
                 $resourceCurrentState.ShadowCopy | Should -BeFalse
@@ -258,7 +278,7 @@ try
         $configurationName = "$($script:dscResourceName)_RemovePermission_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     $configurationParameters = @{
                         OutputPath        = $TestDrive
@@ -266,6 +286,12 @@ try
                     }
 
                     & $configurationName @configurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive
@@ -310,7 +336,7 @@ try
         $configurationName = "$($script:dscResourceName)_RecreateShare1_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     $configurationParameters = @{
                         OutputPath        = $TestDrive
@@ -318,6 +344,12 @@ try
                     }
 
                     & $configurationName @configurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive
@@ -358,7 +390,7 @@ try
         $configurationName = "$($script:dscResourceName)_RemoveShare1_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     $configurationParameters = @{
                         OutputPath        = $TestDrive
@@ -366,6 +398,12 @@ try
                     }
 
                     & $configurationName @configurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive
@@ -404,7 +442,7 @@ try
         $configurationName = "$($script:dscResourceName)_RemoveShare2_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     $configurationParameters = @{
                         OutputPath        = $TestDrive
@@ -412,6 +450,12 @@ try
                     }
 
                     & $configurationName @configurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive
@@ -450,7 +494,7 @@ try
         $configurationName = "$($script:dscResourceName)_Cleanup_Config"
 
         Context ('When using configuration {0}' -f $configurationName) {
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     $configurationParameters = @{
                         OutputPath        = $TestDrive
@@ -458,6 +502,12 @@ try
                     }
 
                     & $configurationName @configurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     $startDscConfigurationParameters = @{
                         Path         = $TestDrive

--- a/tests/Integration/DSC_SystemLocale.Integration.Tests.ps1
+++ b/tests/Integration/DSC_SystemLocale.Integration.Tests.ps1
@@ -43,11 +43,17 @@ try
                     )
                 }
 
-                It 'Should compile and apply the MOF without throwing' {
+                It 'Should compile the MOF without throwing' {
                     {
                         & "$($script:DSCResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
 
                         Start-DscConfiguration `
                             -Path $TestDrive `

--- a/tests/Integration/DSC_TimeZone.Integration.Tests.ps1
+++ b/tests/Integration/DSC_TimeZone.Integration.Tests.ps1
@@ -43,11 +43,17 @@ try
                 )
             }
 
-            It 'Should compile and apply the MOF without throwing' {
+            It 'Should compile the MOF without throwing' {
                 {
                     & "$($script:dscResourceName)_Config" `
                         -OutputPath $TestDrive `
                         -ConfigurationData $configData
+                } | Should -Not -Throw
+            }
+
+            It 'Should apply the MOF without throwing' {
+                {
+                    Reset-DscLcm
 
                     Start-DscConfiguration `
                         -Path $TestDrive `

--- a/tests/Integration/DSC_UserAccountControl.Integration.Tests.ps1
+++ b/tests/Integration/DSC_UserAccountControl.Integration.Tests.ps1
@@ -62,11 +62,17 @@ try
             )
         }
 
-        It 'Should compile and apply the MOF without throwing' {
+        It 'Should compile the MOF without throwing' {
             {
                 & "$($script:dscResourceName)_Config" `
                     -OutputPath $TestDrive `
                     -ConfigurationData $configData
+            } | Should -Not -Throw
+        }
+
+        It 'Should apply the MOF without throwing' {
+            {
+                Reset-DscLcm
 
                 $startDscConfigurationParameters = @{
                     Path         = $TestDrive
@@ -115,11 +121,17 @@ try
             )
         }
 
-        It 'Should compile and apply the MOF without throwing' {
+        It 'Should compile the MOF without throwing' {
             {
                 & "$($script:dscResourceName)_Config" `
                     -OutputPath $TestDrive `
                     -ConfigurationData $configData
+            } | Should -Not -Throw
+        }
+
+        It 'Should apply the MOF without throwing' {
+            {
+                Reset-DscLcm
 
                 $startDscConfigurationParameters = @{
                     Path         = $TestDrive

--- a/tests/Integration/DSC_VirtualMemory.Integration.Tests.ps1
+++ b/tests/Integration/DSC_VirtualMemory.Integration.Tests.ps1
@@ -27,91 +27,99 @@ try
 
         Describe "$($script:dscResourceName)_Integration" {
 
-            Context 'Set page file to automatically managed' {
-                $CurrentConfig = 'setToAuto'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
+            Context 'When setting the page file to automatically managed' {
+                $currentConfig = 'setToAuto'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
 
-                It 'Should compile a MOF file without error' {
+                It 'Should compile the MOF without throwing' {
                     {
-                        . $CurrentConfig -OutputPath $ConfigDir
+                        . $currentConfig -OutputPath $configDir
                     } | Should -Not -Throw
                 }
 
-                It 'Should apply the MOF correctly' {
+                It 'Should apply the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
             }
 
-            Context 'Set page file to custom size' {
-                $CurrentConfig = 'setToCustom'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
+            Context 'When setting the page file to custom size' {
+                $currentConfig = 'setToCustom'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
 
-                It 'Should compile a MOF file without error' {
+                It 'Should compile the MOF without throwing' {
                     {
-                        . $CurrentConfig -OutputPath $ConfigDir
+                        . $currentConfig -OutputPath $configDir
                     } | Should -Not -Throw
                 }
 
-                It 'Should apply the MOF correctly' {
+                It 'Should apply the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
             }
 
-            Context 'Set page file to system managed' {
-                $CurrentConfig = 'setToSystemManaged'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
+            Context 'When setting the page file to system managed' {
+                $currentConfig = 'setToSystemManaged'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
 
-                It 'Should compile a MOF file without error' {
+                It 'Should compile the MOF without throwing' {
                     {
-                        . $CurrentConfig -OutputPath $ConfigDir
+                        . $currentConfig -OutputPath $configDir
                     } | Should -Not -Throw
                 }
 
-                It 'Should apply the MOF correctly' {
+                It 'Should apply the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
             }
 
-            Context 'Set page file to none' {
-                $CurrentConfig = 'setToNone'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
+            Context 'When setting the page file to none' {
+                $currentConfig = 'setToNone'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
 
-                It 'Should compile a MOF file without error' {
+                It 'Should compile the MOF without throwing' {
                     {
-                        . $CurrentConfig -OutputPath $ConfigDir
+                        . $currentConfig -OutputPath $configDir
                     } | Should -Not -Throw
                 }
 
-                It 'Should apply the MOF correctly' {
+                It 'Should apply the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
             }
         }

--- a/tests/Integration/DSC_WindowsCapability.Integration.Tests.ps1
+++ b/tests/Integration/DSC_WindowsCapability.Integration.Tests.ps1
@@ -56,11 +56,17 @@ try
                     )
                 }
 
-                It 'Should compile and apply the MOF without throwing' {
+                It 'Should compile the MOF without throwing' {
                     {
                         & "$($script:dscResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
 
                         $startDscConfigurationParameters = @{
                             Path         = $TestDrive
@@ -103,11 +109,17 @@ try
                     )
                 }
 
-                It 'Should compile and apply the MOF without throwing' {
+                It 'Should compile the MOF without throwing' {
                     {
                         & "$($script:dscResourceName)_Config" `
                             -OutputPath $TestDrive `
                             -ConfigurationData $configData
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
 
                         $startDscConfigurationParameters = @{
                             Path         = $TestDrive

--- a/tests/Integration/DSC_WindowsEventLog.Integration.Tests.ps1
+++ b/tests/Integration/DSC_WindowsEventLog.Integration.Tests.ps1
@@ -26,264 +26,283 @@ try
         . $configFile
 
         Describe "$($script:dscResourceName)_Integration" {
+            Context 'When setting Windows Event Log to Logmode Retain' {
+                $currentConfig = 'DSC_WindowsEventLog_RetainSize'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
 
-            Context 'Set Windows Event Log to Logmode Retain' {
-                $CurrentConfig = 'DSC_WindowsEventLog_RetainSize'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file without error' {
+                It 'Should compile the MOF without throwing' {
                     {
-                        . $CurrentConfig -OutputPath $ConfigDir
+                        . $currentConfig -OutputPath $configDir
                     } | Should -Not -Throw
                 }
 
-                It 'Should apply the MOF correctly' {
+                It 'Should apply the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
-                    } | Should -Not -Throw
-                }
+                        Reset-DscLcm
 
-                It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-                }
-
-                It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
-                }
-            }
-
-            Context 'Set Windows Event Log to Logmode AutoBackup with LogRetentionDays of 30 days' {
-                $CurrentConfig = 'DSC_WindowsEventLog_AutobackupLogRetention'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file without error' {
-                    {
-                        . $CurrentConfig -OutputPath $ConfigDir
-                    } | Should -Not -Throw
-                }
-
-                It 'Should be able to call Get-DscConfiguration without throwing' {
-                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
-                }
-
-                It 'Should apply the MOF correctly' {
-                    {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
-                }
-            }
-
-            Context 'Set Windows Event Log to Logmode Circular, MaximumSizeInBytes 20971520, LogFilePath C:\temp\Application.evtx' {
-                $CurrentConfig = 'DSC_WindowsEventLog_CircularLogPath'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file without error' {
-                    {
-                        . $CurrentConfig -OutputPath $ConfigDir
-                    } | Should -Not -Throw
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
                     { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
+            }
 
-                It 'Should apply the MOF correctly' {
+            Context 'When setting Windows Event Log to Logmode AutoBackup with LogRetentionDays of 30 days' {
+                $currentConfig = 'DSC_WindowsEventLog_AutobackupLogRetention'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+                It 'Should compile the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        . $currentConfig -OutputPath $configDir
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
-                }
-            }
-
-            Context 'Set Windows Event Log to Default' {
-                $CurrentConfig = 'DSC_WindowsEventLog_Default'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file without error' {
-                    {
-                        . $CurrentConfig -OutputPath $ConfigDir
-                    } | Should -Not -Throw
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
                     { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
+            }
 
-                It 'Should apply the MOF correctly' {
+            Context 'When setting Windows Event Log to Logmode Circular, MaximumSizeInBytes 20971520, LogFilePath C:\temp\Application.evtx' {
+                $currentConfig = 'DSC_WindowsEventLog_CircularLogPath'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+                It 'Should compile the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        . $currentConfig -OutputPath $configDir
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
-                }
-            }
-
-            Context 'Enable a Logfile other than Application Eventlog' {
-                $CurrentConfig = 'DSC_WindowsEventLog_EnableLog'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file without error' {
-                    {
-                        . $CurrentConfig -OutputPath $ConfigDir
-                    } | Should -Not -Throw
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
                     { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
+            }
 
-                It 'Should apply the MOF correctly' {
+            Context 'When setting Windows Event Log to Default' {
+                $currentConfig = 'DSC_WindowsEventLog_Default'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+                It 'Should compile the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        . $currentConfig -OutputPath $configDir
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
-                }
-            }
-
-            Context 'Disable a Logfile other than Application Windows Event Log' {
-                $CurrentConfig = 'DSC_WindowsEventLog_DisableLog'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file without error' {
-                    {
-                        . $CurrentConfig -OutputPath $ConfigDir
-                    } | Should -Not -Throw
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
                     { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
+            }
 
-                It 'Should apply the MOF correctly' {
+            Context 'When enabling a Logfile other than Application Eventlog' {
+                $currentConfig = 'DSC_WindowsEventLog_EnableLog'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+                It 'Should compile the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        . $currentConfig -OutputPath $configDir
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
-                }
-            }
-
-            Context 'Set Eventlog to Logmode Circular with a SecurityDescriptor' {
-                $CurrentConfig = 'DSC_WindowsEventLog_CircularSecurityDescriptor'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file without error' {
-                    {
-                        . $CurrentConfig -OutputPath $ConfigDir
-                    } | Should -Not -Throw
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
                     { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
+            }
 
-                It 'Should apply the MOF correctly' {
+            Context 'When disableing a Logfile other than Application Windows Event Log' {
+                $currentConfig = 'DSC_WindowsEventLog_DisableLog'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+                It 'Should compile the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        . $currentConfig -OutputPath $configDir
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
-                }
-            }
-
-            Context 'Enable a Logfile other than Application Windows Event Log with Retention' {
-                $CurrentConfig = 'DSC_WindowsEventLog_EnableBackupLog'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file error' {
-                    {
-                        . $CurrentConfig -OutputPath $ConfigDir
-                    } | Should -Not -Throw
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
                     { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
+            }
 
-                It 'Should not apply the MOF' {
+            Context 'When setting Eventlog to Logmode Circular with a SecurityDescriptor' {
+                $currentConfig = 'DSC_WindowsEventLog_CircularSecurityDescriptor'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+                It 'Should compile the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        . $currentConfig -OutputPath $configDir
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
+                    } | Should -Not -Throw
+                }
+
+                It 'Should return a compliant state after being applied' {
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+            }
+
+            Context 'When enabling a Logfile other than Application Windows Event Log with Retention' {
+                $currentConfig = 'DSC_WindowsEventLog_EnableBackupLog'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+                It 'Should compile the MOF without throwing' {
+                    {
+                        . $currentConfig -OutputPath $configDir
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a incompliant state' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeFalse
-                }
-            }
-
-            Context 'Disable a Logfile other than Application Eventlog with retention' {
-                $CurrentConfig = 'DSC_WindowsEventLog_DisableBackupLog'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file without error' {
-                    {
-                        . $CurrentConfig -OutputPath $ConfigDir
-                    } | Should -Not -Throw
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeFalse
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
                     { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
+            }
 
-                It 'Should apply the MOF correctly' {
+            Context 'When disabling a Logfile other than Application Eventlog with retention' {
+                $currentConfig = 'DSC_WindowsEventLog_DisableBackupLog'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+                It 'Should compile the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        . $currentConfig -OutputPath $configDir
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
-                }
-            }
-
-            Context 'Set Windows Event Log back to the default configuration' {
-                $CurrentConfig = 'DSC_WindowsEventLog_Default'
-                $ConfigDir = (Join-Path -Path $TestDrive -ChildPath $CurrentConfig)
-                $ConfigMof = (Join-Path -Path $ConfigDir -ChildPath 'localhost.mof')
-
-                It 'Should compile a MOF file without error' {
-                    {
-                        . $CurrentConfig -OutputPath $ConfigDir
-                    } | Should -Not -Throw
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
                 }
 
                 It 'Should be able to call Get-DscConfiguration without throwing' {
                     { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
+            }
 
-                It 'Should apply the MOF correctly' {
+            Context 'When setting Windows Event Log back to the default configuration' {
+                $currentConfig = 'DSC_WindowsEventLog_Default'
+                $configDir = (Join-Path -Path $TestDrive -ChildPath $currentConfig)
+                $configMof = (Join-Path -Path $configDir -ChildPath 'localhost.mof')
+
+                It 'Should compile the MOF without throwing' {
                     {
-                        Start-DscConfiguration -Path $ConfigDir -Wait -Verbose -Force
+                        . $currentConfig -OutputPath $configDir
+                    } | Should -Not -Throw
+                }
+
+                It 'Should apply the MOF without throwing' {
+                    {
+                        Reset-DscLcm
+
+                        Start-DscConfiguration -Path $configDir -Wait -Verbose -Force
                     } | Should -Not -Throw
                 }
 
                 It 'Should return a compliant state after being applied' {
-                    (Test-DscConfiguration -ReferenceConfiguration $ConfigMof -Verbose).InDesiredState | Should -BeTrue
+                    (Test-DscConfiguration -ReferenceConfiguration $configMof -Verbose).InDesiredState | Should -BeTrue
+                }
+
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
                 }
             }
         }

--- a/tests/TestHelpers/CommonTestHelper.psm1
+++ b/tests/TestHelpers/CommonTestHelper.psm1
@@ -48,10 +48,12 @@ function Get-InvalidOperationRecord
     [CmdletBinding()]
     param
     (
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String]
         $Message,
 
+        [Parameter()]
         [ValidateNotNull()]
         [System.Management.Automation.ErrorRecord]
         $ErrorRecord
@@ -107,7 +109,41 @@ function Test-WindowsCapabilitySourceAvailable
     return $sourceAvailable
 }
 
+<#
+    .SYNOPSIS
+        Resets the DSC LCM by performing the following functions:
+        1. Cancel any currently executing DSC LCM operations
+        2. Remove any DSC configurations that:
+            - are currently applied
+            - are pending application
+            - have been previously applied
+        The purpose of this function is to ensure the DSC LCM is in a known
+        and idle state before an integration test is performed that will
+        apply a configuration.
+        This is to prevent an integration test from being performed but failing
+        because the DSC LCM is applying a previous configuration.
+        This function should be called after each Describe block in an integration
+        test to ensure the DSC LCM is reset before another test DSC configuration
+        is applied.
+    .EXAMPLE
+        PS C:\> Reset-Dsc
+        This command will reset the DSC LCM and clear out any DSC configurations.
+#>
+function Reset-Dsc
+{
+    [CmdletBinding()]
+    param ()
+
+    Write-Verbose -Message 'Resetting DSC LCM.'
+
+    Stop-DscConfiguration -Force -ErrorAction SilentlyContinue
+    Remove-DscConfigurationDocument -Stage Current -Force
+    Remove-DscConfigurationDocument -Stage Pending -Force
+    Remove-DscConfigurationDocument -Stage Previous -Force
+}
+
 Export-ModuleMember -Function `
     Get-InvalidArgumentRecord, `
     Get-InvalidOperationRecord, `
-    Test-WindowsCapabilitySourceAvailable
+    Test-WindowsCapabilitySourceAvailable, `
+    Reset-Dsc

--- a/tests/TestHelpers/CommonTestHelper.psm1
+++ b/tests/TestHelpers/CommonTestHelper.psm1
@@ -126,10 +126,10 @@ function Test-WindowsCapabilitySourceAvailable
         test to ensure the DSC LCM is reset before another test DSC configuration
         is applied.
     .EXAMPLE
-        PS C:\> Reset-Dsc
+        PS C:\> Reset-DscLcm
         This command will reset the DSC LCM and clear out any DSC configurations.
 #>
-function Reset-Dsc
+function Reset-DscLcm
 {
     [CmdletBinding()]
     param ()
@@ -146,4 +146,4 @@ Export-ModuleMember -Function `
     Get-InvalidArgumentRecord, `
     Get-InvalidOperationRecord, `
     Test-WindowsCapabilitySourceAvailable, `
-    Reset-Dsc
+    Reset-DscLcm


### PR DESCRIPTION
#### Pull Request (PR) description

- ComputerManagementDsc
  - Improved integration test reliability by resetting the DSC LCM
    before executing each test using the `Reset-DscLcm` function - Fixes [Issue #329](https://github.com/dsccommunity/ComputerManagementDsc/issues/329).
  - Split integration test MOF compilation out of application to standardize
    pattern and make it easier to determine cause of failure.

#### This Pull Request (PR) fixes the following issues

- Fixes #329

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/computermanagementdsc/340)
<!-- Reviewable:end -->
