### PR TITLE
Fix PendingReboot Localized Data issue - Fixes #350

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ScheduledTask
   - Fixed issue with disabling scheduled tasks that have "Run whether user is
     logged on or not" configured - Fixes [Issue #306](https://github.com/dsccommunity/ComputerManagementDsc/issues/306).
+- PendingReboot
+  - Fixed issue with loading localized data on non en-US operating systems -
+    Fixes [Issue #350](https://github.com/dsccommunity/ComputerManagementDsc/issues/350).
 
 ## [8.4.0] - 2020-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ScheduledTask
   - Fixed issue with disabling scheduled tasks that have "Run whether user is
     logged on or not" configured - Fixes [Issue #306](https://github.com/dsccommunity/ComputerManagementDsc/issues/306).
+  - Fixed issue with `ExecuteAsCredential` not returning fully qualified username
+    on newer versions of Windows 10 and Windows Server 2019 - Fixes [Issue #352](https://github.com/dsccommunity/ComputerManagementDsc/issues/352).
 - PendingReboot
   - Fixed issue with loading localized data on non en-US operating systems -
     Fixes [Issue #350](https://github.com/dsccommunity/ComputerManagementDsc/issues/350).

--- a/source/DSCResources/DSC_PendingReboot/DSC_PendingReboot.psm1
+++ b/source/DSCResources/DSC_PendingReboot/DSC_PendingReboot.psm1
@@ -18,9 +18,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     when determining if reboot is required. This is stored in a separate
     data file so that it can also be used in testing.
 #>
-$script:localizedResourceData = Import-LocalizedData `
-    -BaseDirectory $PSScriptRoot `
-    -FileName 'DSC_PendingReboot.data.psd1'
+$script:localizedResourceData = Get-LocalizedData `
+    -DefaultUICulture 'en-US' `
+    -FileName 'DSC_PendingReboot.data'
 $script:rebootTriggers = $script:localizedResourceData.RebootTriggers
 <#
     .SYNOPSIS


### PR DESCRIPTION
#### Pull Request (PR) description

This PR corrects Pending Reboot to use `Get-LocalizedData` to read data so that it will work on non en-US OS.

#### This Pull Request (PR) fixes the following issues

- Fixes #350 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this one for me?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/computermanagementdsc/351)
<!-- Reviewable:end -->
