### PR TITLE
ScheduledTask: Remove comparison of StartTime if StartTime is not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     logged on or not" configured - Fixes [Issue #306](https://github.com/dsccommunity/ComputerManagementDsc/issues/306).
   - Fixed issue with `ExecuteAsCredential` not returning fully qualified username
     on newer versions of Windows 10 and Windows Server 2019 - Fixes [Issue #352](https://github.com/dsccommunity/ComputerManagementDsc/issues/352).
+  - Fixed issue with `StartTime` failing Test-Resource if not specified in the
+    resource - Fixes [Issue #148](https://github.com/dsccommunity/ComputerManagementDsc/issues/148).
 - PendingReboot
   - Fixed issue with loading localized data on non en-US operating systems -
     Fixes [Issue #350](https://github.com/dsccommunity/ComputerManagementDsc/issues/350).

--- a/source/DSCResources/DSC_ScheduledTask/DSC_ScheduledTask.psm1
+++ b/source/DSCResources/DSC_ScheduledTask/DSC_ScheduledTask.psm1
@@ -1382,7 +1382,7 @@ function Test-TargetResource
         $PSBoundParameters['RestartInterval'] = (ConvertTo-TimeSpanFromTimeSpanString -TimeSpanString $RestartInterval).ToString()
     }
 
-    if ($ScheduleType -in @('Once', 'Daily', 'Weekly'))
+    if ($ScheduleType -in @('Once', 'Daily', 'Weekly') -and $PSBoundParameters.ContainsKey('StartTime'))
     {
         $PSBoundParameters['StartTime'] = Get-DateTimeString -Date $StartTime -SynchronizeAcrossTimeZone $SynchronizeAcrossTimeZone
         <#
@@ -1405,7 +1405,6 @@ function Test-TargetResource
     }
     else
     {
-        # Do not compare StartTime for triggers that aren't Once, Daily or Weekly.
         $null = $PSBoundParameters.Remove('StartTime')
         $null = $currentValues.Remove('StartTime')
     }


### PR DESCRIPTION
#### Pull Request (PR) description
Skip testing for StartTime when no StartTime is specified and ScheduleType is Once, Daily, or Weekly.

#### This Pull Request (PR) fixes the following issues
    - Fixes #148

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/computermanagementdsc/357)
<!-- Reviewable:end -->
