### PR TITLE
Computer: Delete existing AD Computer object when joining Computer to Domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on and uses the types of changes according to [Keep a Change
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Computer
+  - When joining a computer to a domain, existing AD computer objects will be deleted.
 
 ## [8.5.0] - 2021-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Computer
   - Support Options Parameter for domain join - Fixes [Issue #234](https://github.com/dsccommunity/ComputerManagementDsc/issues/234).
-  - When joining a computer to a domain, existing AD computer objects will be deleted. [Issue #55](https://github.com/dsccommunity/ComputerManagementDsc/issues/55), [Issue #58](https://github.com/dsccommunity/ComputerManagementDsc/issues/58)
+  - When joining a computer to a domain, existing AD computer objects will be deleted - Fixes [Issue #55](https://github.com/dsccommunity/ComputerManagementDsc/issues/55), [Issue #58](https://github.com/dsccommunity/ComputerManagementDsc/issues/58).
 
 ## [8.5.0] - 2021-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ The format is based on and uses the types of changes according to [Keep a Change
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Computer
-  - When joining a computer to a domain, existing AD computer objects will be deleted.
 
 ### Added
+
 - Computer
   - Support Options Parameter for domain join - Fixes [Issue #234](https://github.com/dsccommunity/ComputerManagementDsc/issues/234).
+  - When joining a computer to a domain, existing AD computer objects will be deleted. [Issue #55](https://github.com/dsccommunity/ComputerManagementDsc/issues/55), [Issue #58](https://github.com/dsccommunity/ComputerManagementDsc/issues/58)
 
 ## [8.5.0] - 2021-09-13
 

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -252,7 +252,7 @@ function Set-TargetResource
 
                 if ($computerObject)
                 {
-                    Delete-ADSIObject -Name $computerObject.Path -Credential $Credential
+                    Delete-ADSIObject -Path $computerObject.Path -Credential $Credential
                     Write-Verbose -Message ($script:localizedData.DeletedExistingComputerObject -f @($Name, $computerObject.Path))
                 }
 
@@ -727,7 +727,7 @@ function Delete-ADSIObject
     param
     (
         [Parameter(Mandatory = $true)]
-        [System.DirectoryServices.DirectoryEntry]
+        [System.String]
         $Path,
 
         [Parameter(Mandatory = $true)]
@@ -738,7 +738,7 @@ function Delete-ADSIObject
     try
     {
         $adsiObj = New-Object -TypeName System.DirectoryServices.DirectoryEntry `
-            -ArgumentList $computerObj.Path, $($Credential.UserName), $($Credential.GetNetworkCredential().password) `
+            -ArgumentList $Path, $($Credential.UserName), $($Credential.GetNetworkCredential().password) `
             -ErrorAction Stop
 
         $adsiObj.psbase.DeleteTree()

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -742,7 +742,7 @@ function Delete-ADSIObject
             -ArgumentList $Path, $($Credential.UserName), $($Credential.GetNetworkCredential().password) `
             -ErrorAction Stop
 
-        $adsiObj.psbase.DeleteTree()
+        $adsiObj.DeleteTree()
     }
     catch
     {

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -742,14 +742,7 @@ function Get-ADSIComputer
     $searchRoot = New-Object @params
     $searcher.SearchRoot = $searchRoot
 
-    try
-    {
-        return $searcher.FindOne()
-    }
-    catch
-    {
-        New-InvalidOperationException -Message ($script:localizedData.InvalidUserNameorPassword -f $Credential.Username)
-    }
+    return $searcher.FindOne()
 }
 
 <#
@@ -777,28 +770,19 @@ function Delete-ADSIObject
         $Credential
     )
 
-    try
-    {
-        $params = @{
-            TypeName     = 'System.DirectoryServices.DirectoryEntry'
-            ArgumentList = @(
-                $DomainName,
-                $Credential.UserName
-                $Credential.GetNetworkCredential().password
-            )
-            ErrorAction  = 'Stop'
-        }
-        $adsiObj = New-Object @params
+    $params = @{
+        TypeName     = 'System.DirectoryServices.DirectoryEntry'
+        ArgumentList = @(
+            $DomainName,
+            $Credential.UserName
+            $Credential.GetNetworkCredential().password
+        )
+        ErrorAction  = 'Stop'
+    }
+    $adsiObj = New-Object @params
 
-        $adsiObj.DeleteTree()
-    }
-    catch
-    {
-        New-InvalidOperationException -Message $_.Exception.Message -ErrorRecord $_
-    }
+    $adsiObj.DeleteTree()
 }
-
-Export-ModuleMember -Function *-TargetResource
 
 <#
     .SYNOPSIS
@@ -892,5 +876,6 @@ function Assert-ResourceProperty
             -Message $script:localizedData.InvalidOptionCredentialUnsecuredJoinNullUsername `
             -ArgumentName 'Credential'
     }
-
 }
+
+Export-ModuleMember -Function *-TargetResource

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -728,6 +728,7 @@ function Delete-ADSIObject
     param
     (
         [Parameter(Mandatory = $true)]
+        [ValidateScript( { $_ -imatch "LDAP://*" })]
         [System.String]
         $Path,
 

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -253,7 +253,7 @@ function Set-TargetResource
                 if ($computerObject)
                 {
                     Delete-ADSIObject -Path $computerObject.Path -Credential $Credential
-                    Write-Verbose -Message ($script:localizedData.DeletedExistingComputerObject -f @($Name, $computerObject.Path))
+                    Write-Verbose -Message ($script:localizedData.DeletedExistingComputerObject -f $Name, $computerObject.Path)
                 }
 
                 # Rename the computer, and join it to the domain.

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -757,10 +757,10 @@ function Get-ADSIComputer
         Deletes an ADSI DirectoryEntry Object.
 
     .PARAMETER Path
-        Path to Object to delete
+        Path to Object to delete.
 
     .PARAMETER Credential
-        Credential to authenticate to the domain
+        Credential to authenticate to the domain.
 #>
 function Delete-ADSIObject
 {
@@ -783,9 +783,9 @@ function Delete-ADSIObject
             TypeName     = 'System.DirectoryServices.DirectoryEntry'
             ArgumentList = @(
                 $DomainName,
-                $($Credential.UserName),
-                $($Credential.GetNetworkCredential().password)
-                )
+                $Credential.UserName
+                $Credential.GetNetworkCredential().password
+            )
             ErrorAction  = 'Stop'
         }
         $adsiObj = New-Object @params

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -690,7 +690,8 @@ function Get-ADSIComputer
         $Credential
     )
 
-    $searcher = ([adsisearcher]"(&(objectCategory=computer)(objectClass=computer)(cn=$Name))")
+    $searcher = New-Object -TypeName System.DirectoryServices.DirectorySearcher
+    $searcher.Filter = "(&(objectCategory=computer)(objectClass=computer)(cn=$Name))"
     if ( $DomainName -notlike "LDAP://*")
     {
         $DomainName = "LDAP://$DomainName"

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -92,18 +92,18 @@ function Get-TargetResource
     $convertToCimCredential = New-CimInstance `
         -ClassName DSC_Credential `
         -Property @{
-        Username = [System.String] $Credential.UserName
-        Password = [System.String] $null
-    } `
+            Username = [System.String] $Credential.UserName
+            Password = [System.String] $null
+        } `
         -Namespace root/microsoft/windows/desiredstateconfiguration `
         -ClientOnly
 
     $convertToCimUnjoinCredential = New-CimInstance `
         -ClassName DSC_Credential `
         -Property @{
-        Username = [System.String] $UnjoinCredential.UserName
-        Password = [System.String] $null
-    } `
+            Username = [System.String] $UnjoinCredential.UserName
+            Password = [System.String] $null
+        } `
         -Namespace root/microsoft/windows/desiredstateconfiguration `
         -ClientOnly
 

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -699,9 +699,16 @@ function Get-ADSIComputer
 
     try
     {
-        $searchRoot = New-Object -TypeName System.DirectoryServices.DirectoryEntry `
-            -ArgumentList $DomainName, $($Credential.UserName), $($Credential.GetNetworkCredential().password) `
-            -ErrorAction Stop
+        $params = @{
+            TypeName     = 'System.DirectoryServices.DirectoryEntry'
+            ArgumentList = @(
+                $DomainName,
+                $($Credential.UserName),
+                $($Credential.GetNetworkCredential().password)
+                )
+            ErrorAction  = 'Stop'
+        }
+        $searchRoot = New-Object @params
     }
     catch
     {
@@ -739,9 +746,16 @@ function Delete-ADSIObject
 
     try
     {
-        $adsiObj = New-Object -TypeName System.DirectoryServices.DirectoryEntry `
-            -ArgumentList $Path, $($Credential.UserName), $($Credential.GetNetworkCredential().password) `
-            -ErrorAction Stop
+        $params = @{
+            TypeName     = 'System.DirectoryServices.DirectoryEntry'
+            ArgumentList = @(
+                $DomainName,
+                $($Credential.UserName),
+                $($Credential.GetNetworkCredential().password)
+                )
+            ErrorAction  = 'Stop'
+        }
+        $adsiObj = New-Object @params
 
         $adsiObj.DeleteTree()
     }

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -694,13 +694,13 @@ function Get-LogonServer
         Returns an ADSI Computer Object.
 
     .PARAMETER Name
-        Name of the computer to search for in the given domain
+        Name of the computer to search for in the given domain.
 
     .PARAMETER Domain
-        Domain to search
+        Domain to search.
 
     .PARAMETER Credential
-        Credential to search domain with
+        Credential to search domain with.
 #>
 function Get-ADSIComputer
 {
@@ -725,31 +725,31 @@ function Get-ADSIComputer
 
     $searcher = New-Object -TypeName System.DirectoryServices.DirectorySearcher
     $searcher.Filter = "(&(objectCategory=computer)(objectClass=computer)(cn=$Name))"
-    if ( $DomainName -notlike "LDAP://*")
+    if ($DomainName -notlike "LDAP://*")
     {
         $DomainName = "LDAP://$DomainName"
     }
 
+    $params = @{
+        TypeName     = 'System.DirectoryServices.DirectoryEntry'
+        ArgumentList = @(
+            $DomainName,
+            $Credential.UserName,
+            $Credential.GetNetworkCredential().password
+        )
+        ErrorAction  = 'Stop'
+    }
+    $searchRoot = New-Object @params
+    $searcher.SearchRoot = $searchRoot
+
     try
     {
-        $params = @{
-            TypeName     = 'System.DirectoryServices.DirectoryEntry'
-            ArgumentList = @(
-                $DomainName,
-                $($Credential.UserName),
-                $($Credential.GetNetworkCredential().password)
-                )
-            ErrorAction  = 'Stop'
-        }
-        $searchRoot = New-Object @params
+        return $searcher.FindOne()
     }
     catch
     {
-        New-InvalidOperationException -Message $_.Exception.Message -ErrorRecord $_
+        New-InvalidOperationException -Message ($script:localizedData.InvalidUserNameorPassword -f $Credential.Username)
     }
-    $searcher.SearchRoot = $searchRoot
-
-    return $searcher.FindOne()
 }
 
 <#

--- a/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
+++ b/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
@@ -16,6 +16,5 @@ ConvertFrom-StringData @'
     CheckingWorkgroupMemberMessage = Checking if the machine is a member of workgroup '{0}'.
     DomainNameAndWorkgroupNameError = Only DomainName or WorkGroupName can be specified at once.
     ComputerNotInDomainMessage = This machine is not a domain member.
-    DeletedExistingComputerObject = Deleted existing computer object with name
-    '{0}' at path '{1}'.
+    DeletedExistingComputerObject = Deleted existing computer object with name '{0}' at path '{1}'.
 '@

--- a/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
+++ b/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
@@ -19,4 +19,5 @@ ConvertFrom-StringData @'
     DeletedExistingComputerObject = Deleted existing computer object with name '{0}' at path '{1}'.
     InvalidOptionPasswordPassUnsecuredJoin = Domain Join option 'PasswordPass' may not be specified if 'UnsecuredJoin' is specified.
     InvalidOptionCredentialUnsecuredJoinNullUsername = 'Credential' username must be null if 'UnsecuredJoin' is specified.
+    InvalidUserNameorPassword = Password specified for UserName {0} is invalid.
 '@

--- a/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
+++ b/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
@@ -19,5 +19,4 @@ ConvertFrom-StringData @'
     DeletedExistingComputerObject = Deleted existing computer object with name '{0}' at path '{1}'.
     InvalidOptionPasswordPassUnsecuredJoin = Domain Join option 'PasswordPass' may not be specified if 'UnsecuredJoin' is specified.
     InvalidOptionCredentialUnsecuredJoinNullUsername = 'Credential' username must be null if 'UnsecuredJoin' is specified.
-    InvalidUserNameorPassword = Password specified for UserName {0} is invalid.
 '@

--- a/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
+++ b/source/DSCResources/DSC_Computer/en-US/DSC_Computer.strings.psd1
@@ -16,4 +16,6 @@ ConvertFrom-StringData @'
     CheckingWorkgroupMemberMessage = Checking if the machine is a member of workgroup '{0}'.
     DomainNameAndWorkgroupNameError = Only DomainName or WorkGroupName can be specified at once.
     ComputerNotInDomainMessage = This machine is not a domain member.
+    DeletedExistingComputerObject = Deleted existing computer object with name
+    '{0}' at path '{1}'.
 '@

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1326,7 +1326,7 @@ try
                         Get-ADSIComputer `
                             -Name 'LegalName' `
                             -Domain 'Contoso.com' `
-                            -Credential $credential`
+                            -Credential $credential `
                             -Verbose
                     } | Should -Throw
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -Scope It

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1255,12 +1255,6 @@ try
                      }
                 }
 
-                Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `
-                    -ParameterFilter {
-                        $TypeName -and
-                        $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
-                    }
-
                 Mock 'New-Object' { New-Object 'fake_adsi_searcher' } `
                     -ParameterFilter {
                         $TypeName -and
@@ -1289,6 +1283,12 @@ try
 
                 It 'Returns ADSI object with ADSI path ' {
 
+                    Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `
+                    -ParameterFilter {
+                        $TypeName -and
+                        $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
+                    }
+
                     $obj = Get-ADSIComputer `
                         -Name 'LegalName' `
                         -Domain 'LDAP://Contoso.com' `
@@ -1299,6 +1299,12 @@ try
                 }
 
                 It 'Returns ADSI object with domain name' {
+
+                    Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `
+                    -ParameterFilter {
+                        $TypeName -and
+                        $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
+                    }
 
                     $obj = Get-ADSIComputer `
                             -Name 'LegalName' `
@@ -1336,13 +1342,13 @@ try
                     [void] DeleteTree(){ }
                 }
 
-                Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `
+                It 'Deletes ADSI Object' {
+                    Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `
                     -ParameterFilter {
                         $TypeName -and
                         $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
                     }
 
-                It 'Deletes ADSI Object' {
                     {
                         Delete-ADSIObject `
                             -Path 'LDAP://contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1312,20 +1312,11 @@ try
 
             Context 'DSC_Computer\Delete-ADSIObject' {
 
-                class fake_psbase {
-                    [void] DeleteTree(){ }
-                }
-
                 class fake_adsi_directoryentry {
                     [string] $Domain
                     [string] $Username
                     [string] $password
-                    [fake_psbase] $psbase
-
-                    fake_adsi_directoryentry() {
-                        $this.psbase = `
-                            New-Object -TypeName fake_psbase
-                    }
+                    [void] DeleteTree(){ }
                 }
 
                 Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1289,25 +1289,23 @@ try
 
                 It 'Returns ADSI object with ADSI path ' {
 
-                    {
-                        Get-ADSIComputer `
-                            -Name 'LegalName' `
-                            -Domain 'LDAP://Contoso.com' `
-                            -Credential $credential `
-                            -Verbose
-                    } | Should -Not -BeNullOrEmpty
+                    $obj = Get-ADSIComputer `
+                        -Name 'LegalName' `
+                        -Domain 'LDAP://Contoso.com' `
+                        -Credential $credential `
+                        -Verbose
+                    $obj.path | Should -Be 'LDAP://contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com'
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -Scope It
                 }
 
                 It 'Returns ADSI object with domain name' {
 
-                    {
-                        Get-ADSIComputer `
+                    $obj = Get-ADSIComputer `
                             -Name 'LegalName' `
                             -Domain 'Contoso.com' `
                             -Credential $credential `
                             -Verbose
-                    } | Should -Not -BeNullOrEmpty
+                    $obj.Path | Should -Be 'LDAP://contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com'
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -Scope It
                 }
             }

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1284,13 +1284,14 @@ try
                 }
 
                 Mock -CommandName New-Object -MockWith {
-                        New-Object -TypeName 'fake_adsi_directoryentry'
+                        New-Object -TypeName 'fake_adsi_searcher'
                     } `
                     -ParameterFilter {
                         $TypeName -and
-                        $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
+                        $TypeName -eq 'System.DirectoryServices.DirectorySearcher'
                     }
 
+                $message = "Cannot validate argument on parameter 'Name'. The character length of the 17 argument is too long. Shorten the character length of the argument so it is fewer than or equal to "15" characters, and then try the command again."
                 It 'Should throw the expected exception if the name is to long' {
                     {
                        $error = Get-ADSIComputer `
@@ -1299,7 +1300,7 @@ try
                             -Credential $credential `
                             -Verbose
                         $error
-                    } | Should -Throw "Test-ParamValidator: Cannot validate argument on parameter 'Name'. The character length of the 17 argument is too long. Shorten the character length of the argument so it is fewer than or equal to `"15`" characters, and then try the command again."
+                    } | Should -Throw $message
                 }
 
                 It 'Should throws if the expected exception if the name contains illegal characters' {
@@ -1309,7 +1310,7 @@ try
                             -Domain 'Contoso.com' `
                             -Credential $credential `
                             -Verbose
-                    } | Should -Throw "Test-ParamValidator: Cannot validate argument on parameter 'Name'. The `" $_ -inotmatch '[\/\\:*?`"<>|]' `" validation script for the argument with value `"IllegalName[<`" did not return a result of True. Determine why the validation script failed, and then try the command again."
+                    } | Should -Throw "Cannot validate argument on parameter 'Name'. The `" $_ -inotmatch '[\/\\:*?`"<>|]' `" validation script for the argument with value `"IllegalName[<`" did not return a result of True. Determine why the validation script failed, and then try the command again."
                 }
 
                 It 'Returns ADSI object with ADSI path ' {
@@ -1333,11 +1334,11 @@ try
                 It 'Returns ADSI object with domain name' {
 
                     Mock -CommandName New-Object -MockWith {
-                            New-Object -TypeName 'fake_adsi_directoryentry'
+                            New-Object -TypeName 'fake_adsi_searcher'
                         } `
                         -ParameterFilter {
                             $TypeName -and
-                            $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
+                            $TypeName -eq 'System.DirectoryServices.DirectorySearcher'
                         }
 
                     $obj = Get-ADSIComputer `
@@ -1398,7 +1399,7 @@ try
                             -Path 'contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `
                             -Credential $credential`
                             -Verbose
-                    } | Should -Throw "Test-ParamValidator: Cannot validate argument on parameter 'Path'. The `" $_ -imatch `"LDAP://*`" `" validation script for the argument with value `"contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com`" did not return a result of True. Determine why the validation script failed, and then try the command again."
+                    } | Should -Throw "Cannot validate argument on parameter 'Path'. The `" $_ -imatch `"LDAP://*`" `" validation script for the argument with value `"contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com`" did not return a result of True. Determine why the validation script failed, and then try the command again."
                 }
 
                 It 'Should throw if Credential is incorrect' {

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1316,7 +1316,7 @@ try
                 }
 
                 It 'Should throw if Credential is incorrect' {
-                    Mock 'New-Object' { throw } `
+                    Mock 'New-Object' { Write-Error -message "error" } `
                         -ParameterFilter {
                             $TypeName -and
                             $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
@@ -1368,7 +1368,7 @@ try
                 }
 
                 It 'Should throw if Credential is incorrect' {
-                    Mock 'New-Object' { throw } `
+                    Mock 'New-Object' { Write-Error -message "error" } `
                         -ParameterFilter {
                             $TypeName -and
                             $TypeName -eq 'System.DirectoryServices.DirectoryEntry'

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -45,6 +45,23 @@ try
                 'name'
             }
 
+            # These classes are used in Delete-ADSIObject
+            class fake_psbase_object {
+                [void] DeleteTree(){ }
+            }
+
+            class fake_adsi_directoryentry {
+                [string] $Domain
+                [string] $Username
+                [string] $password
+                [fake_psbase_object] $psbase
+
+                fake_adsi_directoryentry() {
+                    $this.psbase = `
+                        New-Object 'fake_psbase_object'
+                }
+            }
+
             Context 'DSC_Computer\Test-TargetResource' {
                 Mock -CommandName Get-WMIObject -MockWith {
                     [PSCustomObject] @{
@@ -1311,22 +1328,6 @@ try
             }
 
             Context 'DSC_Computer\Delete-ADSIObject' {
-
-                class fake_psbase_object {
-                    [void] DeleteTree(){ }
-                }
-
-                class fake_adsi_directoryentry {
-                    [string] $Domain
-                    [string] $Username
-                    [string] $password
-                    [fake_psbase_object] $psbase
-
-                    fake_adsi_directoryentry() {
-                        $this.psbase = `
-                            New-Object 'fake_psbase_object'
-                    }
-                }
 
                 Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `
                     -ParameterFilter {

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1353,7 +1353,7 @@ try
 
                 It 'Should throw the expected exception if Credential is incorrect' {
                     Mock -CommandName New-Object -MockWith {
-                         Write-Error -message "Invalid Credentials"
+                         Write-Error -message 'Invalid Credentials'
                         } `
                         -ParameterFilter {
                             $TypeName -and

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -45,23 +45,6 @@ try
                 'name'
             }
 
-            # These classes are used in Delete-ADSIObject
-            class fake_psbase_object {
-                [void] DeleteTree(){ }
-            }
-
-            class fake_adsi_directoryentry {
-                [string] $Domain
-                [string] $Username
-                [string] $password
-                [fake_psbase_object] $psbase
-
-                fake_adsi_directoryentry() {
-                    $this.psbase = `
-                        New-Object 'fake_psbase_object'
-                }
-            }
-
             Context 'DSC_Computer\Test-TargetResource' {
                 Mock -CommandName Get-WMIObject -MockWith {
                     [PSCustomObject] @{
@@ -1328,6 +1311,21 @@ try
             }
 
             Context 'DSC_Computer\Delete-ADSIObject' {
+
+
+
+                class fake_adsi_directoryentry {
+                    [string] $Domain
+                    [string] $Username
+                    [string] $password
+                    $psbase
+
+                    fake_adsi_directoryentry() {
+                        $this.psbase = class fake_psbase {
+                            [void] DeleteTree(){ }
+                        }
+                    }
+                }
 
                 Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `
                     -ParameterFilter {

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1313,7 +1313,6 @@ try
             Context 'DSC_Computer\Delete-ADSIObject' {
 
                 class fake_psbase_object {
-                    [string] $name
                     [void] DeleteTree(){ }
                 }
 

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1409,6 +1409,9 @@ try
                             -Verbose
                     } | Should -Throw
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It
+                }
+            }
+
             Context 'DSC_Computer\Assert-ResourceProperty' {
                 It 'Should throw if PasswordPass and UnsecuredJoin is present but credential username is not null' {
                     $errorRecord = Get-InvalidArgumentRecord `

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1361,13 +1361,22 @@ try
                     {
                         Delete-ADSIObject `
                             -Path 'LDAP://contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `
-                            -Domain 'Contoso.com' `
                             -Credential $credential`
                             -Verbose
                     } | Should -Throw
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It
             }
+
+            It 'Should throw if path does not begin with LDAP://' {
+                {
+                    Delete-ADSIObject `
+                            -Path 'contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `
+                            -Credential $credential`
+                            -Verbose
+                    } | Should -Throw
+                }
             }
+
         }
     }
 }

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1303,7 +1303,7 @@ try
                     } | Should -Throw $message
                 }
 
-                $message = "Cannot validate argument on parameter 'Name'. The `" $_ -inotmatch '[\/\\:*?`"<>|]' `" validation script for the argument with value `"IllegalName[<`" did not return a result of True. Determine why the validation script failed, and then try the command again."
+                $message = "Cannot validate argument on parameter 'Name'. The `" `$_ -inotmatch '[\/\\:*?`"<>|]' `" validation script for the argument with value `"IllegalName[<`" did not return a result of True. Determine why the validation script failed, and then try the command again."
                 It 'Should throws if the expected exception if the name contains illegal characters' {
                     {
                         Get-ADSIComputer `
@@ -1394,7 +1394,7 @@ try
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It
                 }
 
-                $message = "Cannot validate argument on parameter 'Path'. The `" $_ -imatch `"LDAP://*`" `" validation script for the argument with value `"contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com`" did not return a result of True. Determine why the validation script failed, and then try the command again."
+                $message = "Cannot validate argument on parameter 'Path'. The `" `$_ -imatch `"LDAP://*`" `" validation script for the argument with value `"contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com`" did not return a result of True. Determine why the validation script failed, and then try the command again."
                 It 'Should throw if path does not begin with LDAP://' {
                     {
                         Delete-ADSIObject `

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1237,6 +1237,28 @@ try
                     Get-LogonServer | Should -Not -BeNullOrEmpty
                 }
             }
+
+            Context 'DSC_Computer\Get-ADSIComputer' {
+                It 'Throws if name is to long' {
+                    {
+                        Get-ADSIComputer `
+                            -Name 'ThisNameIsTooLong' `
+                            -Domain 'Contoso.com' `
+                            -Credential $credential `
+                            -Verbose
+                    } | Should -Throw
+                }
+
+                It 'Throws if name contains illegal characters' {
+                    {
+                        Get-ADSIComputer `
+                            -Name 'IllegalName[<' `
+                            -Domain 'Contoso.com' `
+                            -Credential $credential `
+                            -Verbose
+                    } | Should -Throw
+                }
+            }
         }
     }
 }

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1303,6 +1303,7 @@ try
                     } | Should -Throw $message
                 }
 
+                $message = "Cannot validate argument on parameter 'Name'. The `" $_ -inotmatch '[\/\\:*?`"<>|]' `" validation script for the argument with value `"IllegalName[<`" did not return a result of True. Determine why the validation script failed, and then try the command again."
                 It 'Should throws if the expected exception if the name contains illegal characters' {
                     {
                         Get-ADSIComputer `
@@ -1310,7 +1311,7 @@ try
                             -Domain 'Contoso.com' `
                             -Credential $credential `
                             -Verbose
-                    } | Should -Throw "Cannot validate argument on parameter 'Name'. The `" $_ -inotmatch '[\/\\:*?`"<>|]' `" validation script for the argument with value `"IllegalName[<`" did not return a result of True. Determine why the validation script failed, and then try the command again."
+                    } | Should -Throw $message
                 }
 
                 It 'Returns ADSI object with ADSI path ' {
@@ -1393,13 +1394,14 @@ try
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It
                 }
 
+                $message = "Cannot validate argument on parameter 'Path'. The `" $_ -imatch `"LDAP://*`" `" validation script for the argument with value `"contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com`" did not return a result of True. Determine why the validation script failed, and then try the command again."
                 It 'Should throw if path does not begin with LDAP://' {
                     {
                         Delete-ADSIObject `
                             -Path 'contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `
                             -Credential $credential`
                             -Verbose
-                    } | Should -Throw "Cannot validate argument on parameter 'Path'. The `" $_ -imatch `"LDAP://*`" `" validation script for the argument with value `"contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com`" did not return a result of True. Determine why the validation script failed, and then try the command again."
+                    } | Should -Throw $message
                 }
 
                 It 'Should throw if Credential is incorrect' {

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1291,7 +1291,7 @@ try
                         $TypeName -eq 'System.DirectoryServices.DirectorySearcher'
                     }
 
-                $message = "Cannot validate argument on parameter 'Name'. The character length of the 17 argument is too long. Shorten the character length of the argument so it is fewer than or equal to "15" characters, and then try the command again."
+                $message = "Cannot validate argument on parameter 'Name'. The character length of the 17 argument is too long. Shorten the character length of the argument so it is fewer than or equal to `"15`" characters, and then try the command again."
                 It 'Should throw the expected exception if the name is to long' {
                     {
                        $error = Get-ADSIComputer `

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -619,8 +619,6 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $WorkGroupName -and $NewName -and $credential }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $DomainName -or $UnjoinCredential }
-                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 1 -Scope It
                 }
 
                 It 'Changes ComputerName and changes Workgroup to Domain' {
@@ -862,8 +860,6 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $WorkGroupName -and $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $DomainName }
-                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Changes only the Domain to new Domain' {
@@ -1013,8 +1009,6 @@ try
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $WorkGroupName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $DomainName }
-                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
-                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Changes only Domain to Workgroup when Name is [localhost]' {

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1312,18 +1312,19 @@ try
 
             Context 'DSC_Computer\Delete-ADSIObject' {
 
-
+                class fake_psbase {
+                    [void] DeleteTree(){ }
+                }
 
                 class fake_adsi_directoryentry {
                     [string] $Domain
                     [string] $Username
                     [string] $password
-                    $psbase
+                    [fake_psbase] $psbase
 
                     fake_adsi_directoryentry() {
-                        $this.psbase = class fake_psbase {
-                            [void] DeleteTree(){ }
-                        }
+                        $this.psbase = `
+                            New-Object -TypeName fake_psbase
                     }
                 }
 

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -485,6 +485,8 @@ try
             Context 'DSC_Computer\Set-TargetResource' {
                 Mock -CommandName Rename-Computer
                 Mock -CommandName Set-CimInstance
+                Mock -CommandName Get-ADSIComputer
+                Mock -CommandName Delete-ADSIObject
 
                 It 'Throws if both DomainName and WorkGroupName are specified' {
                     $errorRecord = Get-InvalidOperationRecord `
@@ -531,6 +533,12 @@ try
                         }
                     }
 
+                    Mock -CommandName Get-ADSIComputer -MockWith {
+                        [PSCustomObject] @{
+                            Path       = 'LDAP://Contoso.com/CN=mocked-comp,OU=Computers,DC=Contoso,DC=com';
+                        }
+                    }
+
                     Mock -CommandName Get-ComputerDomain -MockWith {
                         'contoso.com'
                     }
@@ -547,6 +555,8 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName -and $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 1 -Scope It
                 }
 
                 It 'Changes ComputerName and changes Domain to new Domain with specified OU' {
@@ -562,6 +572,12 @@ try
                         'contoso.com'
                     }
 
+                    Mock -CommandName Get-ADSIComputer -MockWith {
+                        [PSCustomObject] @{
+                            Path       = 'LDAP://Contoso.com/CN=mocked-comp,OU=Computers,DC=Contoso,DC=com';
+                        }
+                    }
+
                     Mock -CommandName Add-Computer
 
                     Set-TargetResource `
@@ -575,6 +591,8 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName -and $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 1 -Scope It
                 }
 
                 It 'Changes ComputerName and changes Domain to Workgroup' {
@@ -601,6 +619,8 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $WorkGroupName -and $NewName -and $credential }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $DomainName -or $UnjoinCredential }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 1 -Scope It
                 }
 
                 It 'Changes ComputerName and changes Workgroup to Domain' {
@@ -609,6 +629,12 @@ try
                             Domain       = 'Contoso';
                             Workgroup    = 'Contoso';
                             PartOfDomain = $false
+                        }
+                    }
+
+                    Mock -CommandName Get-ADSIComputer -MockWith {
+                        [PSCustomObject] @{
+                            Path       = 'LDAP://Contoso.com/CN=mocked-comp,OU=Computers,DC=Contoso,DC=com';
                         }
                     }
 
@@ -627,6 +653,8 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName -and $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 1 -Scope It
                 }
 
                 It 'Changes ComputerName and changes Workgroup to Domain with specified Domain Controller' {
@@ -635,6 +663,12 @@ try
                             Domain       = 'Contoso';
                             Workgroup    = 'Contoso';
                             PartOfDomain = $false
+                        }
+                    }
+
+                    Mock -CommandName Get-ADSIComputer -MockWith {
+                        [PSCustomObject] @{
+                            Path       = 'LDAP://Contoso.com/CN=mocked-comp,OU=Computers,DC=Contoso,DC=com';
                         }
                     }
 
@@ -654,6 +688,8 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName -and $NewName -and $Server }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 1 -Scope It
                 }
 
                 It 'Changes ComputerName and changes Workgroup to Domain with specified OU' {
@@ -662,6 +698,12 @@ try
                             Domain       = 'Contoso';
                             Workgroup    = 'Contoso';
                             PartOfDomain = $false
+                        }
+                    }
+
+                    Mock -CommandName Get-ADSIComputer -MockWith {
+                        [PSCustomObject] @{
+                            Path       = 'LDAP://Contoso.com/CN=mocked-comp,OU=Computers,DC=Contoso,DC=com';
                         }
                     }
 
@@ -681,6 +723,8 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName -and $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 1 -Scope It
                 }
 
                 It 'Should try a separate rename if ''FailToRenameAfterJoinDomain'' occured during domain join' {
@@ -696,6 +740,10 @@ try
                             Workgroup    = 'Contoso'
                             PartOfDomain = $false
                         }
+                    }
+
+                    Mock -CommandName Get-ADSIComputer -MockWith {
+                        $null
                     }
 
                     Mock -CommandName Get-ComputerDomain -MockWith {
@@ -715,6 +763,8 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 1 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName -and $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Should Throw the correct error if Add-Computer errors with an unknown InvalidOperationException' {
@@ -785,6 +835,8 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName -and $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Changes ComputerName and changes Workgroup to new Workgroup' {
@@ -810,6 +862,8 @@ try
                     Assert-MockCalled -CommandName Rename-Computer -Exactly -Times 0 -Scope It
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $WorkGroupName -and $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $DomainName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Changes only the Domain to new Domain' {
@@ -838,6 +892,8 @@ try
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Changes only the Domain to new Domain when name is [localhost]' {
@@ -866,6 +922,8 @@ try
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Changes only the Domain to new Domain with specified OU' {
@@ -895,6 +953,8 @@ try
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Changes only the Domain to new Domain with specified OU when Name is [localhost]' {
@@ -924,6 +984,8 @@ try
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $DomainName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $WorkGroupName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Changes only Domain to Workgroup' {
@@ -951,6 +1013,8 @@ try
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $NewName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 1 -Scope It -ParameterFilter { $WorkGroupName }
                     Assert-MockCalled -CommandName Add-Computer -Exactly -Times 0 -Scope It -ParameterFilter { $DomainName }
+                    Assert-MockCalled -CommandName Get-ADSIComputer -Exactly -Times 1 -Scope It
+                    Assert-MockCalled -CommandName Delete-ADSIObject -Exactly -Times 0 -Scope It
                 }
 
                 It 'Changes only Domain to Workgroup when Name is [localhost]' {

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1324,6 +1324,7 @@ try
                             -Verbose
                     } | Should -Throw
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -Scope It
+                }
             }
 
             Context 'DSC_Computer\Delete-ADSIObject' {
@@ -1351,6 +1352,15 @@ try
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It
                 }
 
+                It 'Should throw if path does not begin with LDAP://' {
+                    {
+                        Delete-ADSIObject `
+                                -Path 'contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `
+                                -Credential $credential`
+                                -Verbose
+                    } | Should -Throw
+                }
+
                 It 'Should throw if Credential is incorrect' {
                     Mock 'New-Object' { throw } `
                         -ParameterFilter {
@@ -1365,18 +1375,8 @@ try
                             -Verbose
                     } | Should -Throw
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It
-            }
-
-            It 'Should throw if path does not begin with LDAP://' {
-                {
-                    Delete-ADSIObject `
-                            -Path 'contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `
-                            -Credential $credential`
-                            -Verbose
-                    } | Should -Throw
                 }
             }
-
         }
     }
 }

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1308,6 +1308,22 @@ try
                     $obj.Path | Should -Be 'LDAP://contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com'
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -Scope It
                 }
+
+                It 'Should throw if Credential is incorrect' {
+                    Mock 'New-Object' { throw } `
+                        -ParameterFilter {
+                            $TypeName -and
+                            $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
+                        }
+
+                    {
+                        Get-ADSIComputer `
+                            -Name 'LegalName' `
+                            -Domain 'Contoso.com' `
+                            -Credential $credential`
+                            -Verbose
+                    } | Should -Throw
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -Scope It
             }
 
             Context 'DSC_Computer\Delete-ADSIObject' {
@@ -1334,6 +1350,23 @@ try
                     } | Should -Not -Throw
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It
                 }
+
+                It 'Should throw if Credential is incorrect' {
+                    Mock 'New-Object' { throw } `
+                        -ParameterFilter {
+                            $TypeName -and
+                            $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
+                        }
+
+                    {
+                        Delete-ADSIObject `
+                            -Path 'LDAP://contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `
+                            -Domain 'Contoso.com' `
+                            -Credential $credential`
+                            -Verbose
+                    } | Should -Throw
+                    Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It
+            }
             }
         }
     }

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1321,6 +1321,11 @@ try
                     [string] $Username
                     [string] $password
                     [fake_psbase_object] $psbase
+
+                    fake_adsi_directoryentry() {
+                        $this.psbase = `
+                            New-Object 'fake_psbase_object'
+                    }
                 }
 
                 Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1352,7 +1352,9 @@ try
                 }
 
                 It 'Should throw the expected exception if Credential is incorrect' {
-                    Mock 'New-Object' { Write-Error -message "Invalid Credentials" } `
+                    Mock -CommandName New-Object -MockWith {
+                         Write-Error -message "Invalid Credentials"
+                        } `
                         -ParameterFilter {
                             $TypeName -and
                             $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
@@ -1364,13 +1366,12 @@ try
                             -Domain 'Contoso.com' `
                             -Credential $credential `
                             -Verbose
-                    } | Should -Throw "Invalid Credentials"
+                    } | Should -Throw 'Invalid Credentials'
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 2 -Scope It
                 }
             }
 
             Context 'DSC_Computer\Delete-ADSIObject' {
-
                 class fake_adsi_directoryentry {
                     [string] $Domain
                     [string] $Username
@@ -1379,11 +1380,13 @@ try
                 }
 
                 It 'Should delete the ADSI Object' {
-                    Mock 'New-Object' { New-Object 'fake_adsi_directoryentry' } `
-                    -ParameterFilter {
-                        $TypeName -and
-                        $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
-                    }
+                    Mock -CommandName New-Object -MockWith {
+                        New-Object 'fake_adsi_directoryentry'
+                        } `
+                        -ParameterFilter {
+                            $TypeName -and
+                            $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
+                        }
 
                     {
                         Delete-ADSIObject `
@@ -1404,8 +1407,10 @@ try
                     } | Should -Throw $message
                 }
 
-                It 'Should throw if Credential is incorrect' {
-                    Mock 'New-Object' { Write-Error -message "Invalid Credential" } `
+                It 'Should throw the expected exception if Credential is incorrect' {
+                    Mock -CommandName New-Object -MockWith {
+                        Write-Error -message 'Invalid Credential'
+                        } `
                         -ParameterFilter {
                             $TypeName -and
                             $TypeName -eq 'System.DirectoryServices.DirectoryEntry'
@@ -1416,7 +1421,7 @@ try
                             -Path 'LDAP://contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `
                             -Credential $credential `
                             -Verbose
-                    } | Should -Throw "Invalid Credential"
+                    } | Should -Throw 'Invalid Credential'
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It
                 }
             }

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1377,7 +1377,7 @@ try
                     {
                         Delete-ADSIObject `
                             -Path 'LDAP://contoso.com/CN=fake-computer,OU=Computers,DC=contoso,DC=com' `
-                            -Credential $credential`
+                            -Credential $credential `
                             -Verbose
                     } | Should -Throw
                     Assert-MockCalled -CommandName New-Object -Exactly -Times 1 -Scope It

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1313,6 +1313,7 @@ try
             Context 'DSC_Computer\Delete-ADSIObject' {
 
                 class fake_psbase_object {
+                    [string] $name
                     [void] DeleteTree(){ }
                 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

When joining a computer to a domain, if a computer object with the same name already exists in the domain it will be deleted.

#### This Pull Request (PR) fixes the following issues

- Fixes #55 
- Fixes #58 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/computermanagementdsc/386)
<!-- Reviewable:end -->
