### PR TITLE
SmbShare, UserAccountControl - fix issues with access control parameters, DWord registry value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - AppVeyor build now sets the correct module version to be able to run tests.
 - ScheduledTask
   - Allowed values for ScheduleType updated to accept AtLogon over AtLogOn - Fixes [Issue #420](https://github.com/dsccommunity/ComputerManagementDsc/issues/420)
+- SmbShare
+  - Allow Test-TargetResource to succeed when access entries use different order - Fixes [Issue #247](https://github.com/dsccommunity/ComputerManagementDsc/issues/247), [Issue #423](https://github.com/dsccommunity/ComputerManagementDsc/issues/423)
+- UserAccountControl
+  - Ensure registry keys are created as REG_DWORD rather than REG_SZ - Fixes [Issue #412](https://github.com/dsccommunity/ComputerManagementDsc/issues/412)
 
 ## [9.0.0] - 2023-02-22
 

--- a/source/DSCResources/DSC_SmbShare/DSC_SmbShare.psm1
+++ b/source/DSCResources/DSC_SmbShare/DSC_SmbShare.psm1
@@ -531,6 +531,7 @@ function Test-TargetResource
             $resourceRequiresUpdate = Test-DscParameterState `
                 -CurrentValues $currentSmbShareConfiguration `
                 -DesiredValues $PSBoundParameters `
+                -SortArrayValues `
                 -Verbose:$VerbosePreference
         }
         else

--- a/source/DSCResources/DSC_UserAccountControl/DSC_UserAccountControl.psm1
+++ b/source/DSCResources/DSC_UserAccountControl/DSC_UserAccountControl.psm1
@@ -225,6 +225,7 @@ function Set-TargetResource
                         Path = $script:registryKey
                         Name = $parameterName
                         Value = $PSBoundParameters.$parameterName
+                        Type = 'DWord'
                         ErrorAction = 'Stop'
                     }
 
@@ -533,6 +534,7 @@ function Set-UserAccountControlToNotificationLevel
     {
         $defaultSetItemPropertyParameters = @{
             Path = $script:registryKey
+            Type = 'DWord'
             ErrorAction = 'Stop'
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Allow SmbShare Test-TargetResource to succeed when access entries use different order
Ensure registry keys of UserAccountControl are created as REG_DWORD rather than REG_SZ

#### This Pull Request (PR) fixes the following issues

- Fixes #247
- Fixes #423
- Fixes #412

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ComputerManagementDsc/424)
<!-- Reviewable:end -->
