### PR TITLE
Fix Get-DomainName - retrieve computer NETBIOS domain name instead of user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Computer
+  - Fix Get-ComputerDomain function to retrieve the computer NETBIOS domain name instead of the user.
+
 ## [10.0.0] - 2025-01-25
 
 ### Added

--- a/source/DSCResources/DSC_Computer/DSC_Computer.psm1
+++ b/source/DSCResources/DSC_Computer/DSC_Computer.psm1
@@ -630,7 +630,7 @@ function Get-ComputerDomain
         {
             if ($NetBios)
             {
-                $domainName = (Get-Item -Path Env:\USERDOMAIN).Value
+                $domainName = (Get-CimInstance -ClassName Win32_NTDomain -Filter "DnsForestName='$($domainInfo.Domain)'").DomainName
             }
             else
             {

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1707,17 +1707,17 @@ Describe 'DSC_Computer\Get-ComputerDomain' -Tag 'Private' {
                 }
             }
 
-            Mock -CommandName Get-Item -ParameterFilter { $Path -eq 'Env:\USERDOMAIN' } -MockWith {
+            Mock -CommandName Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_NTDomain' } -MockWith {
                 [PSCustomObject] @{
-                    Value = 'CONTOSO'
+                    DomainName    = 'CONTOSO'
                 }
             }
         }
 
         BeforeDiscovery {
             $testCases = @(
-                @{ value = $true; result = 'CONTOSO'; GetItemCount = 1 }
-                @{ value = $false; result = 'contoso.com'; GetItemCount = 0 }
+                @{ value = $true; result = 'CONTOSO'; GetCimInstanceCount = 2 }
+                @{ value = $false; result = 'contoso.com'; GetCimInstanceCount = 1 }
             )
         }
 
@@ -1733,8 +1733,7 @@ Describe 'DSC_Computer\Get-ComputerDomain' -Tag 'Private' {
                     Get-ComputerDomain @getComputerDomainParameters | Should -Be $result
                 }
 
-                Should -Invoke -CommandName Get-CimInstance -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Get-Item -Exactly -Times $GetItemCount -Scope It
+                Should -Invoke -CommandName Get-CimInstance -Exactly -Times $GetCimInstanceCount -Scope It
             }
         }
 
@@ -1747,9 +1746,9 @@ Describe 'DSC_Computer\Get-ComputerDomain' -Tag 'Private' {
                     }
                 }
 
-                Mock -CommandName Get-Item -ParameterFilter { $Path -eq 'Env:\USERDOMAIN' } -MockWith {
+                Mock -CommandName Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_NTDomain' } -MockWith {
                     [PSCustomObject] @{
-                        Value = 'CONTOSO'
+                        DomainName = 'CONTOSO'
                     }
                 }
             }
@@ -1761,7 +1760,6 @@ Describe 'DSC_Computer\Get-ComputerDomain' -Tag 'Private' {
                 }
 
                 Should -Invoke -CommandName Get-CimInstance -Exactly -Times 1 -Scope It
-                Should -Invoke -CommandName Get-Item -Exactly -Times 0 -Scope It
             }
         }
 
@@ -1782,9 +1780,9 @@ Describe 'DSC_Computer\Get-ComputerDomain' -Tag 'Private' {
                         }
                     }
 
-                    Mock -CommandName Get-Item -ParameterFilter { $Path -eq 'Env:\USERDOMAIN' } -MockWith {
+                    Mock -CommandName Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_NTDomain' } -MockWith {
                         [PSCustomObject] @{
-                            Value = 'Computer1'
+                            DomainName = $null
                         }
                     }
                 }
@@ -1801,7 +1799,6 @@ Describe 'DSC_Computer\Get-ComputerDomain' -Tag 'Private' {
                     }
 
                     Should -Invoke -CommandName Get-CimInstance -Exactly -Times 1 -Scope It
-                    Should -Invoke -CommandName Get-Item -Exactly -Times 0 -Scope It
                 }
             }
         }

--- a/tests/Unit/DSC_Computer.Tests.ps1
+++ b/tests/Unit/DSC_Computer.Tests.ps1
@@ -1709,7 +1709,7 @@ Describe 'DSC_Computer\Get-ComputerDomain' -Tag 'Private' {
 
             Mock -CommandName Get-CimInstance -ParameterFilter { $ClassName -eq 'Win32_NTDomain' } -MockWith {
                 [PSCustomObject] @{
-                    DomainName    = 'CONTOSO'
+                    DomainName = 'CONTOSO'
                 }
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description

Spotted this issue the other day - when requesting the NETBIOS domain name, Get-ComputerDomain is returning the user's domain name, not the computer's. It is possible for a user from another domain to log on to this computer.

It looks like the NETBIOS functionality is not actually used at present, but fixing this in case it is used in future.

#### This Pull Request (PR) fixes the following issues


#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/ComputerManagementDsc/444)
<!-- Reviewable:end -->
